### PR TITLE
indicatorIconWidget: Fix TypeError from missing _batteryBounds in dot layout

### DIFF
--- a/lib/widgets/indicatorIconWidget.js
+++ b/lib/widgets/indicatorIconWidget.js
@@ -100,20 +100,16 @@ export const IndicatorIconWidget = GObject.registerClass({
             batteryScale,
         };
 
-        if (this._widgetInfo.levelIndicatorType === 0) {
-            const batteryWidth = 15;
-            const batteryHeight = 2.6;
-            const batteryX = (svgSize - batteryWidth) / 2;
-            const batteryY = svgSize - batteryHeight;
+		const batteryWidth = 15;
+		const batteryHeight = 2.6;
+		const batteryX = (svgSize - batteryWidth) / 2;
+		const batteryY = svgSize - batteryHeight;
+
+		if (this._widgetInfo.levelIndicatorType === 0) {
             this._precomputeBarLayouts(batteryX, batteryY, batteryWidth, batteryHeight, false);
         } else {
-            const batteryWidth = 15;
-            const batteryHeight = 2.6;
-            const batteryX = (svgSize - batteryWidth) / 2;
-            const batteryY = svgSize - batteryHeight;
             this._precomputeDotLayouts(batteryX, batteryY, batteryWidth, batteryHeight);
         }
-
         this._cairoCacheSurface = loadFileToCairoSurface(filePath, textureScale);
 
         this.queue_repaint();
@@ -281,6 +277,9 @@ export const IndicatorIconWidget = GObject.registerClass({
             {cx: startX + 2 * (d + spacer) + r, cy},
             {cx: startX + 3 * (d + spacer) + r, cy},
         ];
+
+		this._batteryBounds = this._batteryBounds || {};
+		this._batteryBounds.barX = x;
     }
 
     _drawDotLevel(cr) {
@@ -323,7 +322,8 @@ export const IndicatorIconWidget = GObject.registerClass({
             else
                 this._drawDotLevel(cr);
         } else if (this._indicatorMode === 1) {
-            cr.translate(this._batteryBounds.barX, 0);
+			const barX = this._batteryBounds?.barX ?? 0;
+			cr.translate(barX, 0);
             const placeImageBelowDeviceIcon = this._widgetInfo.levelIndicatorType === 1 ||
                     this._widgetInfo.levelBarPosition === 2;
             const vectorImage = placeImageBelowDeviceIcon ? 'h-non-battery' : 'v-non-battery';


### PR DESCRIPTION
_drawWidget() accessed this._batteryBounds.barX when indicatorMode === 1, but _batteryBounds was only set by _precomputeBarLayouts(). In the dots layout, _precomputeDotLayouts() didn’t populate it, causing _drawWidget to constantly spam logs with TypeError.

- Cleaned up repeating battery geometry constants
- _precomputeDotLayouts() explicitly sets _batteryBounds.barX for _drawWidget()'s translate
- _drawWidget() ensures _batteryBounds before translate

```bash
gnome-shell[2904]: JS ERROR: TypeError: this._batteryBounds is undefined
                                                  _drawWidget@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/widgets/indicatorIconWidget.js:326:26
                                                  vfunc_repaint@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/widgets/indicatorIconWidget.js:349:14
                                                  updateValues@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/widgets/indicatorIconWidget.js:356:18
                                                  _iconWithBatteryLevel/<@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/widgets/bluetoothIndicator.js:103:48
                                                  _generateAccessors/propdesc.set@resource:///org/gnome/gjs/modules/core/_common.js:38:26
                                                  _updateUI/<@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/widgetManagerEnhanced.js:129:21
                                                  setProps@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/dataHandler.js:188:14
                                                  updateBatteryProps@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/airpods/airpodsDevice.js:490:35
                                                  _parseBatteryStatus@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/airpods/airpodsSocket.js:194:29
                                                  processData@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/airpods/airpodsSocket.js:93:18
                                                  _receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:75:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
                                                  async*_receiveLoop@file:///home/thomas/.local/share/gnome-shell/extensions/Bluetooth-Battery-Meter@maniacx.github.com/lib/devices/socketByProfile.js:77:18
```