### PR TITLE
feat: implement packet fragmentation handling to support multi-part GFPS data transmission

### DIFF
--- a/lib/devices/gfps/gfpsSocket.js
+++ b/lib/devices/gfps/gfpsSocket.js
@@ -29,24 +29,46 @@ export const GfpsSocket = GObject.registerClass({
     }
 
     processData(bytes) {
-        if (bytes.length < 4) {
-            this._log.info(`Discarding short GFPS packet: len=${bytes.length}`);
-            return;
+        let isValid = false;
+
+        if (bytes.length >= 4) {
+            const len = bytes[2] << 8 | bytes[3];
+            if (bytes.length === 4 + len) {
+                isValid = true;
+            }
         }
 
-        const group = bytes[0];
-        const code = bytes[1];
-        const len = bytes[2] << 8 | bytes[3];
+        let packetToProcess = bytes;
 
-        if (bytes.length !== 4 + len) {
-            this._log.info(
-                `Discarding malformed GFPS packet: expected=${4 + len} actual=${bytes.length}`
-            );
-            return;
+        if (isValid) {
+            this._halfPacket = new Uint8Array(0);
+        } else if (this._halfPacket.length > 0) {
+            const merged = new Uint8Array(this._halfPacket.length + bytes.length);
+            merged.set(this._halfPacket, 0);
+            merged.set(bytes, this._halfPacket.length);
+            packetToProcess = merged;
+
+            if (packetToProcess.length >= 4) {
+                const len = packetToProcess[2] << 8 | packetToProcess[3];
+                if (packetToProcess.length === 4 + len) {
+                    isValid = true;
+                }
+            }
         }
 
-        const payload = bytes.slice(4);
-        this._parseData(group, code, payload);
+        if (isValid) {
+            const group = packetToProcess[0];
+            const code = packetToProcess[1];
+            const payload = packetToProcess.slice(4);
+            this._halfPacket = new Uint8Array(0);
+            this._parseData(group, code, payload);
+        } else {
+            if (packetToProcess.length > 512) {
+                this._halfPacket = new Uint8Array(0);
+            } else {
+                this._halfPacket = packetToProcess;
+            }
+        }
     }
 
     postConnectInitialization() {


### PR DESCRIPTION
As requested, I've focused solely on resolving issues with packet buffer management. This will now verify the first chunk as valid, and if valid discards any lingering half-packet memory to prevent corruption loops. If its invalid itll fall back to appending the new bytes to the lingering half-packet buffer. Any buffers beyond 512 bytes is dropped as a failsafe.